### PR TITLE
Align trending solution card sizes

### DIFF
--- a/src/components/marketplace/SolutionCard.tsx
+++ b/src/components/marketplace/SolutionCard.tsx
@@ -18,7 +18,7 @@ const SolutionCard: React.FC<SolutionCardProps> = ({ solution, showActions = tru
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-sm hover:shadow-md transition-all duration-300 overflow-hidden group">
+    <div className="bg-white rounded-xl shadow-sm hover:shadow-md transition-all duration-300 overflow-hidden group flex flex-col h-full">
       <div className="relative">
         <img
           src={solution.image}
@@ -31,13 +31,13 @@ const SolutionCard: React.FC<SolutionCardProps> = ({ solution, showActions = tru
         </div>
       </div>
       
-      <div className="p-6">
+      <div className="p-6 flex flex-col flex-grow">
         <div className="flex items-center space-x-2 mb-2">
           <Tag className="h-4 w-4 text-blue-700" />
           <span className="text-sm font-medium text-blue-700">{solution.category}</span>
         </div>
         
-        <h3 className="text-xl font-semibold mb-2 group-hover:text-blue-700 transition-colors">
+        <h3 className="text-xl font-semibold mb-2 group-hover:text-blue-700 transition-colors line-clamp-2">
           {solution.title}
         </h3>
         
@@ -78,7 +78,7 @@ const SolutionCard: React.FC<SolutionCardProps> = ({ solution, showActions = tru
         {showActions && (
           <button
             onClick={handleAction}
-            className="mt-4 w-full inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-700 hover:bg-blue-800 transition-colors"
+            className="mt-4 w-full inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-700 hover:bg-blue-800 transition-colors mt-auto"
           >
             View Details
             <ArrowUpRight className="ml-2 h-4 w-4" />

--- a/src/components/marketplace/TrendingSolutions.tsx
+++ b/src/components/marketplace/TrendingSolutions.tsx
@@ -25,8 +25,8 @@ const TrendingSolutions: React.FC<TrendingSolutionsProps> = ({ solutions }) => {
         </Link>
       </div>
 
-      {solutions && Array.isArray(solutions) && solutions.length > 0 ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {solutions && Array.isArray(solutions) && solutions.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 auto-rows-fr">
           {solutions.map((solution) => (
             <SolutionCard
               key={solution.id}


### PR DESCRIPTION
## Summary
- ensure trending solution cards in the Marketplace share equal height
- update SolutionCard styles to use flex layout so cards stretch evenly
- apply grid auto-rows to TrendingSolutions for consistent box sizes

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_684940445b5883229976518c42612956