### PR TITLE
Improve solution page grid layout

### DIFF
--- a/src/pages/solutions/index.tsx
+++ b/src/pages/solutions/index.tsx
@@ -82,10 +82,10 @@ const Solutions = () => {
           </div>
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 auto-rows-fr">
           {userSolutions.map((solution) => (
-            <div key={solution.id} className="bg-white shadow rounded-lg">
-              <div className="p-6">
+            <div key={solution.id} className="bg-white shadow rounded-lg flex flex-col h-full">
+              <div className="p-6 flex flex-col flex-grow">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center">
                     <Package className="h-10 w-10 text-blue-600" />


### PR DESCRIPTION
## Summary
- display solution cards in a responsive grid
- stretch each card to uniform height

## Testing
- `npm test`
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68496ca2a74c8322906cadc4926b192e